### PR TITLE
Improve hex layout generation

### DIFF
--- a/scripts/catanGenerator.js
+++ b/scripts/catanGenerator.js
@@ -28,7 +28,7 @@ const createLayout = () => {
     [0, 1, 2, 3, 2, 1, 0].forEach((rowNumber) => {
         const rowElement = document.createElement('div');
         rowElement.classList.add("row");
-        rowElement.classList.add(`row${rowNumber}`);
+        rowElement.style.setProperty('--indent', Math.abs(3 - rowNumber));
 
         for (let i = 0; i < rowNumber + 4; i++) {
             const hexElement = document.createElement('img');

--- a/style/board.css
+++ b/style/board.css
@@ -10,18 +10,11 @@
 .row {
     display: flex;
     margin-top: -48px;
+    margin-left: calc(var(--hex-offset) * var(--indent, 0));
 }
 
-.row0 {
-    margin-left: calc(76px * 3);
-}
-
-.row1 {
-    margin-left: calc(76px * 2);
-}
-
-.row2 {
-    margin-left: 76px;
+:root {
+    --hex-offset: 76px;
 }
 
 #board {


### PR DESCRIPTION
## Summary
- use a CSS variable and inline style to compute row indents
- remove hard-coded row classes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684068a8a3dc8325ad2bc103b13d644d