### PR TITLE
Fix missing desert image when disabling fishermen mode

### DIFF
--- a/scripts/catanGenerator.js
+++ b/scripts/catanGenerator.js
@@ -246,7 +246,7 @@ const generateNewBoard = () => {
         fishDots.forEach((fishDot) => fishDot.style.display = "none")
         hexes.forEach((hex) => {
             if (hex.src.toString().includes("images/lake.jpg")) {
-                hex.src = "images/desert.jpg"
+                hex.src = "images/desert.png"
             }
         })
     }


### PR DESCRIPTION
## Summary
- bugfix: use `desert.png` instead of nonexistent `desert.jpg` when reverting from lake to desert

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6840688e07b0832581b21591250c556f